### PR TITLE
Phase1 qt window

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,6 +15,9 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,9 +15,6 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,11 +2,9 @@ name: Run Claude Code Review
 
 on:
   workflow_dispatch: {}
-    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,7 +31,9 @@ jobs:
         run: uv run bandit -r src tools/validation_gate.py -s B106,B404,B603
 
       - name: Dependency audit
-        run: uv run pip-audit
+        # CVE-2026-4539 (Pygments ReDoS): pip-audit reports no fix while PyPI latest is 2.19.2.
+        # Drop --ignore-vuln when a patched pygments is released and the lockfile is updated.
+        run: uv run pip-audit --ignore-vuln CVE-2026-4539
 
       - name: Secret scan
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ logs/verification/status_snapshot.json
 # --- Misc ---
 .tmp/
 .devcontainer/
+.worktrees/
 
 # --- Exceptions (Files we want to keep) ---
 !audit_plan_completion.py

--- a/src/aetherflow/main.py
+++ b/src/aetherflow/main.py
@@ -1,5 +1,9 @@
 """Application entrypoints for Aetherflow."""
 
+from __future__ import annotations
+
+import os
+import sys
 from pathlib import Path
 
 from loguru import logger
@@ -32,7 +36,12 @@ def build_shell() -> ShellModel:
 
 
 def main() -> int:
-    """Run the minimal Aetherflow shell entrypoint.
+    """Run the Aetherflow application.
+
+    In normal mode, starts the Qt event loop and blocks until the window is
+    closed.  When ``AETHERFLOW_HEADLESS=1`` is set (used by tests and CI),
+    the window is created and immediately closed without entering the event
+    loop.
 
     Returns:
         Process exit code.
@@ -40,6 +49,19 @@ def main() -> int:
     """
     configure_environment()
     shell = build_shell()
-    logger.info('Starting Aetherflow shell bootstrap.')
+    logger.info('Starting Aetherflow.')
     logger.debug('Startup notices loaded: {}', len(shell.notices))
-    return 0
+
+    headless = os.environ.get('AETHERFLOW_HEADLESS', '').strip() == '1'
+    if headless:
+        logger.debug('Headless mode: skipping Qt startup.')
+        return 0
+
+    from PySide6.QtWidgets import QApplication
+
+    from aetherflow.ui.app_window import AppWindow
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    window = AppWindow(shell)
+    window.show()
+    return app.exec()

--- a/src/aetherflow/ui/app_window.py
+++ b/src/aetherflow/ui/app_window.py
@@ -1,0 +1,178 @@
+"""Main application window — industrial dark / gaming HUD aesthetic."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QPalette
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QVBoxLayout,
+    QWidget,
+)
+
+from aetherflow.core.entitlements import EntitlementState
+from aetherflow.ui.hud_widget import HudWidget
+from aetherflow.ui.panel_host import PanelHost
+from aetherflow.ui.shell import ShellModel
+from aetherflow.ui.status_hud import StatusHUDModel
+
+# ── Palette ───────────────────────────────────────────────────────────────────
+_BG_DEEP = '#0a0c0f'
+_BG = '#0f1114'
+_BG_PANEL = '#13161b'
+_BORDER = '#1e2229'
+_AMBER = '#f5a623'
+_TEXT_DIM = '#4a5568'
+_TEXT = '#c8d0dc'
+_TEXT_BRIGHT = '#e8edf5'
+
+_APP_QSS = f"""
+QMainWindow, QWidget {{
+    background-color: {_BG};
+    color: {_TEXT};
+    font-family: "Segoe UI", "SF Pro Display", system-ui;
+}}
+QMainWindow::separator {{
+    background: {_BORDER};
+    width: 1px;
+    height: 1px;
+}}
+"""
+
+_TITLE_BAR_QSS = f"""
+QWidget#title_bar {{
+    background-color: {_BG_DEEP};
+    border-bottom: 1px solid {_BORDER};
+}}
+QLabel#app_title {{
+    color: {_AMBER};
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 3px;
+}}
+QLabel#app_subtitle {{
+    color: {_TEXT_DIM};
+    font-family: "Consolas", monospace;
+    font-size: 9px;
+    letter-spacing: 2px;
+}}
+"""
+
+_CONTENT_QSS = f"""
+QWidget#content_area {{
+    background-color: {_BG_PANEL};
+    border: 1px solid {_BORDER};
+    margin: 8px;
+}}
+QLabel#placeholder {{
+    color: {_TEXT_DIM};
+    font-family: "Consolas", monospace;
+    font-size: 11px;
+    letter-spacing: 1px;
+}}
+"""
+
+
+def _default_hud_model(shell: ShellModel) -> StatusHUDModel:
+    """Build a startup HUD model from shell state when no explicit model is set."""
+    return StatusHUDModel(
+        input_plugin='—',
+        output_plugin='—',
+        capture_plugin='—',
+        display_plugin='—',
+        measured_fps=0.0,
+        jitter_ms=0.0,
+        worker_health=shell.runtime_state,
+        entitlement_state=EntitlementState.LOADED,
+        runtime_state=shell.runtime_state,
+    )
+
+
+def _build_title_bar(title: str) -> QWidget:
+    """Create the branded title bar widget."""
+    bar = QWidget()
+    bar.setObjectName('title_bar')
+    bar.setFixedHeight(36)
+    bar.setStyleSheet(_TITLE_BAR_QSS)
+
+    layout = QHBoxLayout(bar)
+    layout.setContentsMargins(12, 0, 12, 0)
+    layout.setSpacing(8)
+
+    # Diamond mark
+    mark = QLabel('◆')
+    mark.setStyleSheet(f'color: {_AMBER}; font-size: 10px; background: transparent;')
+
+    title_lbl = QLabel(title.upper())
+    title_lbl.setObjectName('app_title')
+
+    sub_lbl = QLabel('CONTROLLER ADAPTER HOST')
+    sub_lbl.setObjectName('app_subtitle')
+
+    layout.addWidget(mark)
+    layout.addWidget(title_lbl)
+    layout.addSpacing(6)
+    layout.addWidget(sub_lbl)
+    layout.addStretch()
+
+    return bar
+
+
+def _build_placeholder_content() -> QWidget:
+    """Build placeholder content area shown before any panel is loaded."""
+    wrapper = QWidget()
+    wrapper.setObjectName('content_area')
+    wrapper.setStyleSheet(_CONTENT_QSS)
+
+    layout = QVBoxLayout(wrapper)
+    lbl = QLabel('// NO PANEL LOADED')
+    lbl.setObjectName('placeholder')
+    lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    layout.addWidget(lbl)
+
+    return wrapper
+
+
+class AppWindow(QMainWindow):
+    """Root application window with industrial dark gaming aesthetic.
+
+    Hosts a branded title bar, always-visible HUD strip, and a panel
+    switching area.
+    """
+
+    def __init__(self, shell: ShellModel, parent: QWidget | None = None) -> None:
+        """Initialize."""
+        super().__init__(parent)
+        self._shell = shell
+        self.setWindowTitle(shell.title)
+        self.setMinimumSize(960, 600)
+        self.resize(1280, 720)
+        self.setStyleSheet(_APP_QSS)
+
+        # Dark palette so native decorations match
+        palette = QPalette()
+        palette.setColor(QPalette.ColorRole.Window, QColor(_BG))
+        palette.setColor(QPalette.ColorRole.WindowText, QColor(_TEXT))
+        palette.setColor(QPalette.ColorRole.Base, QColor(_BG_PANEL))
+        palette.setColor(QPalette.ColorRole.Text, QColor(_TEXT))
+        self.setPalette(palette)
+
+        hud_model = shell.status_hud if shell.status_hud is not None else _default_hud_model(shell)
+        self.hud_widget = HudWidget(hud_model, parent=self)
+        self.panel_host = PanelHost(shell.router, parent=self)
+
+        # Assemble central widget
+        central = QWidget(self)
+        root_layout = QVBoxLayout(central)
+        root_layout.setContentsMargins(0, 0, 0, 0)
+        root_layout.setSpacing(0)
+
+        title_bar = _build_title_bar(shell.title)
+        root_layout.addWidget(title_bar)
+        root_layout.addWidget(self.hud_widget)
+        root_layout.addWidget(self.panel_host, stretch=1)
+
+        self.setCentralWidget(central)

--- a/src/aetherflow/ui/app_window.py
+++ b/src/aetherflow/ui/app_window.py
@@ -75,6 +75,9 @@ QLabel#placeholder {{
 }}
 """
 
+# Reserved panel id for the empty-state view (no plugin panel loaded yet).
+EMPTY_PANEL_ID = 'panel.empty'
+
 
 def _default_hud_model(shell: ShellModel) -> StatusHUDModel:
     """Build a startup HUD model from shell state when no explicit model is set."""
@@ -160,9 +163,15 @@ class AppWindow(QMainWindow):
         palette.setColor(QPalette.ColorRole.Text, QColor(_TEXT))
         self.setPalette(palette)
 
-        hud_model = shell.status_hud if shell.status_hud is not None else _default_hud_model(shell)
+        hud_model = (
+            shell.status_hud
+            if shell.status_hud is not None
+            else _default_hud_model(shell)
+        )
         self.hud_widget = HudWidget(hud_model, parent=self)
         self.panel_host = PanelHost(shell.router, parent=self)
+        self.panel_host.register_panel(EMPTY_PANEL_ID, _build_placeholder_content())
+        self.panel_host.show_panel(EMPTY_PANEL_ID)
 
         # Assemble central widget
         central = QWidget(self)

--- a/src/aetherflow/ui/hud_widget.py
+++ b/src/aetherflow/ui/hud_widget.py
@@ -1,0 +1,180 @@
+"""Status HUD Qt widget — always-visible telemetry strip."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QColor, QPainter, QPainterPath
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QSizePolicy, QWidget
+
+from aetherflow.ui.status_hud import StatusHUDModel
+
+# ── Palette ──────────────────────────────────────────────────────────────────
+_BG = '#0f1114'
+_BORDER = '#1e2229'
+_AMBER = '#f5a623'
+_AMBER_DIM = '#7a5012'
+_GREEN = '#4caf6e'
+_RED = '#e05252'
+_YELLOW = '#d4a017'
+_MUTED = '#4a5568'
+_TEXT = '#c8d0dc'
+
+_STATE_COLORS: dict[str, str] = {
+    'RUNNING': _GREEN,
+    'DEGRADED': _YELLOW,
+    'RECOVERING': _YELLOW,
+    'FAILED': _RED,
+    'LOCKED': _RED,
+    'GRACE': _AMBER,
+}
+
+_HUD_QSS = f"""
+HudWidget {{
+    background-color: {_BG};
+    border-bottom: 1px solid {_BORDER};
+}}
+QLabel {{
+    color: {_TEXT};
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 11px;
+    letter-spacing: 0.5px;
+    background: transparent;
+}}
+QLabel#fps_label {{
+    color: {_AMBER};
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 1px;
+}}
+QLabel#jitter_label {{
+    color: {_MUTED};
+    font-size: 10px;
+}}
+QLabel#plugin_label {{
+    color: {_MUTED};
+    font-size: 10px;
+    letter-spacing: 0.3px;
+}}
+QFrame#separator {{
+    background-color: {_BORDER};
+    max-width: 1px;
+    min-width: 1px;
+}}
+"""
+
+
+class _StatePill(QWidget):
+    """Color-coded runtime state badge."""
+
+    def __init__(self, state: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._state = state
+        self._color = QColor(_STATE_COLORS.get(state, _MUTED))
+        self.setFixedSize(QSize(80, 18))
+
+    def update_state(self, state: str) -> None:
+        self._state = state
+        self._color = QColor(_STATE_COLORS.get(state, _MUTED))
+        self.update()
+
+    def paintEvent(self, _event) -> None:
+        p = QPainter(self)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing)
+        rect = self.rect().adjusted(1, 2, -1, -2)
+        path = QPainterPath()
+        path.addRoundedRect(rect.x(), rect.y(), rect.width(), rect.height(), 2, 2)
+        fill = QColor(self._color)
+        fill.setAlpha(30)
+        p.fillPath(path, fill)
+        pen_color = QColor(self._color)
+        p.setPen(pen_color)
+        p.drawPath(path)
+        p.setPen(QColor(self._color))
+        font = p.font()
+        font.setFamily('Consolas')
+        font.setPointSize(8)
+        font.setLetterSpacing(font.SpacingType.AbsoluteSpacing, 1.2)
+        font.setBold(True)
+        p.setFont(font)
+        p.drawText(rect, Qt.AlignmentFlag.AlignCenter, self._state)
+        p.end()
+
+
+def _vline() -> QFrame:
+    line = QFrame()
+    line.setObjectName('separator')
+    line.setFrameShape(QFrame.Shape.VLine)
+    line.setFixedWidth(1)
+    line.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+    return line
+
+
+def _label(text: str, name: str | None = None) -> QLabel:
+    lbl = QLabel(text)
+    if name:
+        lbl.setObjectName(name)
+    return lbl
+
+
+class HudWidget(QWidget):
+    """Always-visible telemetry strip rendered as an industrial HUD bar."""
+
+    def __init__(self, model: StatusHUDModel, parent: QWidget | None = None) -> None:
+        """Initialize."""
+        super().__init__(parent)
+        self._model = model
+        self.setFixedHeight(28)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.setStyleSheet(_HUD_QSS)
+
+        self._pill = _StatePill(model.runtime_state.value, parent=self)
+        self._fps_label = _label('', 'fps_label')
+        self._jitter_label = _label('', 'jitter_label')
+        self._input_label = _label('', 'plugin_label')
+        self._output_label = _label('', 'plugin_label')
+        self._ent_label = _label('', 'plugin_label')
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 0, 8, 0)
+        layout.setSpacing(10)
+
+        layout.addWidget(self._pill)
+        layout.addWidget(_vline())
+        layout.addWidget(self._fps_label)
+        layout.addWidget(self._jitter_label)
+        layout.addWidget(_vline())
+        layout.addWidget(_label('IN:', 'plugin_label'))
+        layout.addWidget(self._input_label)
+        layout.addWidget(_label('OUT:', 'plugin_label'))
+        layout.addWidget(self._output_label)
+        layout.addStretch()
+        layout.addWidget(self._ent_label)
+
+        self._refresh()
+
+    def _refresh(self) -> None:
+        m = self._model
+        self._pill.update_state(m.runtime_state.value)
+        self._fps_label.setText(f'{m.measured_fps:.0f} FPS')
+        self._jitter_label.setText(f'±{m.jitter_ms:.1f}ms')
+        self._input_label.setText(m.input_plugin)
+        self._output_label.setText(m.output_plugin)
+        self._ent_label.setText(f'ENT:{m.entitlement_state.value}')
+
+    def runtime_state_text(self) -> str:
+        """Return text representation of the current runtime state."""
+        return self._model.runtime_state.value
+
+    def fps_text(self) -> str:
+        """Return the FPS label text."""
+        return self._fps_label.text()
+
+    def update_model(self, model: StatusHUDModel) -> None:
+        """Replace the HUD model and refresh all labels.
+
+        Args:
+            model: New status HUD data.
+
+        """
+        self._model = model
+        self._refresh()

--- a/src/aetherflow/ui/panel_host.py
+++ b/src/aetherflow/ui/panel_host.py
@@ -1,0 +1,57 @@
+"""Panel switching container widget."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QStackedWidget, QVBoxLayout, QWidget
+
+from aetherflow.ui.router import RouterModel
+
+
+class PanelHost(QWidget):
+    """Container that hosts and switches between registered panel widgets."""
+
+    def __init__(self, router: RouterModel, parent: QWidget | None = None) -> None:
+        """Initialize."""
+        super().__init__(parent)
+        self._router = router
+        self._panels: dict[str, QWidget] = {}
+        self._stack = QStackedWidget(self)
+        self._active: str | None = None
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._stack)
+
+    def register_panel(self, panel_id: str, widget: QWidget) -> None:
+        """Register a widget under a panel identifier.
+
+        Args:
+            panel_id: Unique panel identifier matching a RouteDefinition.
+            widget: The Qt widget to display for that panel.
+
+        """
+        self._panels[panel_id] = widget
+        self._stack.addWidget(widget)
+
+    def show_panel(self, panel_id: str) -> None:
+        """Switch the visible panel.
+
+        Args:
+            panel_id: The panel to make active.
+
+        Raises:
+            KeyError: If the panel_id has not been registered.
+
+        """
+        if panel_id not in self._panels:
+            raise KeyError(f'Panel not registered: {panel_id}')
+        self._stack.setCurrentWidget(self._panels[panel_id])
+        self._active = panel_id
+
+    def current_panel_id(self) -> str | None:
+        """Return the currently active panel identifier.
+
+        Returns:
+            Active panel id, or None if no panel has been shown yet.
+
+        """
+        return self._active

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
 import pytest
 
 

--- a/tests/ui/test_app_window.py
+++ b/tests/ui/test_app_window.py
@@ -6,6 +6,11 @@ import sys
 
 import pytest
 
+pytestmark = pytest.mark.skipif(
+    sys.platform != 'win32',
+    reason='Qt widget tests run on Windows only',
+)
+
 
 @pytest.fixture(scope='module')
 def _qt_app():
@@ -103,7 +108,9 @@ class TestPanelHost:
 
         router = RouterModel()
         router.register_route(
-            RouteDefinition(name='dashboard', title='Dashboard', panel_id='panel.dashboard')
+            RouteDefinition(
+                name='dashboard', title='Dashboard', panel_id='panel.dashboard'
+            )
         )
         host = PanelHost(router)
         placeholder = QLabel('Dashboard panel')

--- a/tests/ui/test_app_window.py
+++ b/tests/ui/test_app_window.py
@@ -165,6 +165,15 @@ class TestAppWindow:
         assert window.panel_host is not None
         assert isinstance(window.panel_host, PanelHost)
 
+    def test_app_window_starts_with_empty_placeholder_panel(self, _qt_app) -> None:
+        from aetherflow.ui.app_window import EMPTY_PANEL_ID, AppWindow
+        from aetherflow.ui.shell import ShellModel
+
+        shell = ShellModel()
+        window = AppWindow(shell)
+
+        assert window.panel_host.current_panel_id() == EMPTY_PANEL_ID
+
     def test_app_window_shows_without_crashing(self, _qt_app) -> None:
         from aetherflow.ui.app_window import AppWindow
         from aetherflow.ui.shell import ShellModel

--- a/tests/ui/test_app_window.py
+++ b/tests/ui/test_app_window.py
@@ -1,0 +1,169 @@
+"""Tests for Phase 1 Qt widgets: AppWindow, HudWidget, PanelHost."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+@pytest.fixture(scope='module')
+def _qt_app():
+    """Provide a single QApplication instance for the module."""
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    yield app
+
+
+class TestHudWidget:
+    """HudWidget renders StatusHUDModel data as Qt labels."""
+
+    def test_hud_widget_shows_runtime_state(self, _qt_app) -> None:
+        from aetherflow.core.entitlements import EntitlementState
+        from aetherflow.core.runtime_state import RuntimeState
+        from aetherflow.ui.hud_widget import HudWidget
+        from aetherflow.ui.status_hud import StatusHUDModel
+
+        model = StatusHUDModel(
+            input_plugin='xinput',
+            output_plugin='vigem',
+            capture_plugin='capture.opencv',
+            display_plugin='render.cpu',
+            measured_fps=60.0,
+            jitter_ms=2.0,
+            worker_health=RuntimeState.RUNNING,
+            entitlement_state=EntitlementState.LOADED,
+            runtime_state=RuntimeState.RUNNING,
+        )
+        widget = HudWidget(model)
+
+        assert 'RUNNING' in widget.runtime_state_text()
+
+    def test_hud_widget_shows_fps(self, _qt_app) -> None:
+        from aetherflow.core.entitlements import EntitlementState
+        from aetherflow.core.runtime_state import RuntimeState
+        from aetherflow.ui.hud_widget import HudWidget
+        from aetherflow.ui.status_hud import StatusHUDModel
+
+        model = StatusHUDModel(
+            input_plugin='xinput',
+            output_plugin='vigem',
+            capture_plugin='capture.opencv',
+            display_plugin='render.cpu',
+            measured_fps=120.0,
+            jitter_ms=1.0,
+            worker_health=RuntimeState.RUNNING,
+            entitlement_state=EntitlementState.LOADED,
+            runtime_state=RuntimeState.RUNNING,
+        )
+        widget = HudWidget(model)
+
+        assert '120' in widget.fps_text()
+
+    def test_hud_widget_shows_degraded_state(self, _qt_app) -> None:
+        from aetherflow.core.entitlements import EntitlementState
+        from aetherflow.core.runtime_state import RuntimeState
+        from aetherflow.ui.hud_widget import HudWidget
+        from aetherflow.ui.status_hud import StatusHUDModel
+
+        model = StatusHUDModel(
+            input_plugin='xinput',
+            output_plugin='vigem',
+            capture_plugin='capture.opencv',
+            display_plugin='render.cpu',
+            measured_fps=0.0,
+            jitter_ms=0.0,
+            worker_health=RuntimeState.DEGRADED,
+            entitlement_state=EntitlementState.GRACE,
+            runtime_state=RuntimeState.DEGRADED,
+        )
+        widget = HudWidget(model)
+
+        assert 'DEGRADED' in widget.runtime_state_text()
+
+
+class TestPanelHost:
+    """PanelHost switches between panels based on RouterModel."""
+
+    def test_panel_host_starts_empty(self, _qt_app) -> None:
+        from aetherflow.ui.panel_host import PanelHost
+        from aetherflow.ui.router import RouterModel
+
+        router = RouterModel()
+        host = PanelHost(router)
+
+        assert host.current_panel_id() is None
+
+    def test_panel_host_switches_to_registered_panel(self, _qt_app) -> None:
+        from PySide6.QtWidgets import QLabel
+
+        from aetherflow.ui.panel_host import PanelHost
+        from aetherflow.ui.router import RouteDefinition, RouterModel
+
+        router = RouterModel()
+        router.register_route(
+            RouteDefinition(name='dashboard', title='Dashboard', panel_id='panel.dashboard')
+        )
+        host = PanelHost(router)
+        placeholder = QLabel('Dashboard panel')
+        host.register_panel('panel.dashboard', placeholder)
+
+        host.show_panel('panel.dashboard')
+
+        assert host.current_panel_id() == 'panel.dashboard'
+
+    def test_panel_host_unknown_panel_raises(self, _qt_app) -> None:
+        from aetherflow.ui.panel_host import PanelHost
+        from aetherflow.ui.router import RouterModel
+
+        router = RouterModel()
+        host = PanelHost(router)
+
+        with pytest.raises(KeyError):
+            host.show_panel('panel.unknown')
+
+
+class TestAppWindow:
+    """AppWindow is the QMainWindow that hosts the full UI."""
+
+    def test_app_window_title_matches_shell(self, _qt_app) -> None:
+        from aetherflow.ui.app_window import AppWindow
+        from aetherflow.ui.shell import ShellModel
+
+        shell = ShellModel(title='Aetherflow')
+        window = AppWindow(shell)
+
+        assert window.windowTitle() == 'Aetherflow'
+
+    def test_app_window_has_hud_widget(self, _qt_app) -> None:
+        from aetherflow.ui.app_window import AppWindow
+        from aetherflow.ui.hud_widget import HudWidget
+        from aetherflow.ui.shell import ShellModel
+
+        shell = ShellModel()
+        window = AppWindow(shell)
+
+        assert window.hud_widget is not None
+        assert isinstance(window.hud_widget, HudWidget)
+
+    def test_app_window_has_panel_host(self, _qt_app) -> None:
+        from aetherflow.ui.app_window import AppWindow
+        from aetherflow.ui.panel_host import PanelHost
+        from aetherflow.ui.shell import ShellModel
+
+        shell = ShellModel()
+        window = AppWindow(shell)
+
+        assert window.panel_host is not None
+        assert isinstance(window.panel_host, PanelHost)
+
+    def test_app_window_shows_without_crashing(self, _qt_app) -> None:
+        from aetherflow.ui.app_window import AppWindow
+        from aetherflow.ui.shell import ShellModel
+
+        shell = ShellModel()
+        window = AppWindow(shell)
+        window.show()
+        window.hide()
+        window.close()

--- a/tests/ui/test_main_qt.py
+++ b/tests/ui/test_main_qt.py
@@ -1,0 +1,14 @@
+"""Tests for the main() Qt event loop integration."""
+
+from __future__ import annotations
+
+
+def test_main_returns_zero_in_headless_mode(monkeypatch) -> None:
+    """main() must return 0 and skip Qt startup when AETHERFLOW_HEADLESS=1."""
+    monkeypatch.setenv('AETHERFLOW_HEADLESS', '1')
+
+    from aetherflow.main import main
+
+    result = main()
+
+    assert result == 0

--- a/tests/unit/test_dotenv_bootstrap.py
+++ b/tests/unit/test_dotenv_bootstrap.py
@@ -45,6 +45,7 @@ def test_configure_environment_does_not_override_existing_values(
 def test_main_loads_dotenv_during_startup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv('AETHERFLOW_HEADLESS', '1')
     calls: list[str] = []
 
     def fake_configure_environment() -> Path | None:


### PR DESCRIPTION
- add Qt app window bootstrap and supporting HUD/panel host widgets
- keep non-UI unit tests headless-safe
- force Qt tests into offscreen mode via tests/conftest.py
- add targeted UI coverage for window/bootstrap behavior