### PR TITLE
Make shell startup role-aware and attach default plugin catalog

### DIFF
--- a/src/aetherflow/main.py
+++ b/src/aetherflow/main.py
@@ -1,16 +1,23 @@
 """Application entrypoints for Aetherflow."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 from loguru import logger
 
 from aetherflow.core.developer_app_checks import PendingAppCheckStore
 from aetherflow.core.dotenv_bootstrap import configure_environment
+from aetherflow.core.entitlements import RoleName
+from aetherflow.ui.bootstrap import configure_default_shell
 from aetherflow.ui.shell import ShellModel
 
 
-def build_shell() -> ShellModel:
-    """Build the shell model and load pending developer app checks.
+def build_shell(*, role: RoleName = RoleName.POWER_GAMER) -> ShellModel:
+    """Build the shell model, load notices, and configure startup UI.
+
+    Args:
+        role: Active role used to configure the default startup shell.
 
     Returns:
         Shell model ready for startup.
@@ -22,13 +29,12 @@ def build_shell() -> ShellModel:
         snapshot_path=Path('logs') / 'verification' / 'status_snapshot.json',
     )
 
-    # Load pending alerts and acknowledge each so they don't reappear next startup
     pending_alerts = store.pending_alerts()
     shell.load_pending_app_checks(pending_alerts)
     for alert in pending_alerts:
         store.acknowledge(alert.item_id)
 
-    return shell
+    return configure_default_shell(shell, role=role)
 
 
 def main() -> int:

--- a/src/aetherflow/ui/shell.py
+++ b/src/aetherflow/ui/shell.py
@@ -1,10 +1,10 @@
-
 """Minimal shell composition models."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
@@ -13,6 +13,9 @@ from aetherflow.core.entitlements import RoleName
 from aetherflow.core.runtime_state import RuntimeState
 from aetherflow.ui.router import RouterModel
 from aetherflow.ui.status_hud import StatusHUDModel
+
+if TYPE_CHECKING:
+    from aetherflow.ui.panels.plugin_catalog_panel import PluginCatalogPanelModel
 
 
 @dataclass(slots=True)
@@ -35,6 +38,7 @@ class ShellModel:
     router: RouterModel = field(default_factory=RouterModel)
     notices: list[ShellNotice] = field(default_factory=list)
     status_hud: StatusHUDModel | None = None
+    plugin_catalog: PluginCatalogPanelModel | None = None
 
     def mark_degraded(self, plugin_id: str) -> None:
         """Record a degraded plugin without terminating the shell."""
@@ -104,6 +108,15 @@ class ShellModel:
 
         """
         self.status_hud = hud
+
+    def set_plugin_catalog(self, catalog: PluginCatalogPanelModel) -> None:
+        """Update the plugin catalog model.
+
+        Args:
+            catalog: New plugin catalog panel model.
+
+        """
+        self.plugin_catalog = catalog
 
     def set_active_route(self, route_name: str, *, role: RoleName | None) -> str:
         """Activate a route and track its panel.

--- a/tests/ui/test_shell_router.py
+++ b/tests/ui/test_shell_router.py
@@ -81,6 +81,7 @@ def test_shell_records_route_failures() -> None:
 
 
 def test_router_rejects_unauthorized_navigation() -> None:
+    """Reject navigation for roles that cannot access a route."""
     router = RouterModel()
     router.register_route(
         RouteDefinition(
@@ -100,6 +101,7 @@ def test_router_rejects_unauthorized_navigation() -> None:
 
 
 def test_build_shell_loads_pending_app_check_notices(monkeypatch, tmp_path) -> None:
+    """Load notices first and attach the default startup catalog."""
     verification_dir = tmp_path / 'logs' / 'verification'
     verification_dir.mkdir(parents=True)
     (verification_dir / 'pending_app_checks.json').write_text(
@@ -119,3 +121,27 @@ def test_build_shell_loads_pending_app_check_notices(monkeypatch, tmp_path) -> N
 
     assert len(shell.notices) == 1
     assert 'check for functionality' in shell.notices[0].message.lower()
+    assert shell.plugin_catalog is not None
+    assert [entry.plugin_id for entry in shell.plugin_catalog.entries] == [
+        'input.xinput',
+        'input.kbm',
+        'capture.mf',
+    ]
+
+
+def test_build_shell_accepts_admin_role_for_default_routes() -> None:
+    """Preserve role-aware startup route registration through build_shell."""
+    shell = build_shell(role=RoleName.ADMIN_OPERATOR)
+
+    assert [
+        route.name
+        for route in shell.router.available_routes(role=RoleName.ADMIN_OPERATOR)
+    ] == [
+        'home',
+        'catalog',
+        'capture',
+        'workers',
+        'environment',
+        'resources',
+        'admin',
+    ]


### PR DESCRIPTION
### Motivation

- Provide role-aware startup configuration so the UI registers appropriate default routes and panels for the active role. 
- Centralize default shell composition (including plugin catalog) into a bootstrap helper so `build_shell` can remain minimal.

### Description

- Change `build_shell` to accept a `role: RoleName` parameter with default `RoleName.POWER_GAMER` and return `configure_default_shell(shell, role=role)` instead of returning the raw `ShellModel`.
- Add `plugin_catalog: PluginCatalogPanelModel | None` field and `set_plugin_catalog` method to `ShellModel`, and use `TYPE_CHECKING` for the panel type import to avoid runtime imports.
- Import `RoleName` and `configure_default_shell` in `main.py` and add `from __future__ import annotations` where needed to support forward references.
- Update unit tests in `tests/ui/test_shell_router.py` to verify plugin catalog attachment and role-aware startup routes, and to exercise unauthorized navigation handling.

### Testing

- Ran unit tests in `tests/ui/test_shell_router.py` with `pytest`, and all tests passed. 
- The updated tests include `test_build_shell_loads_pending_app_check_notices` and `test_build_shell_accepts_admin_role_for_default_routes`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c15376edf4832081c747bb5ab190b5)